### PR TITLE
Add name to metadata

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,7 +1,7 @@
+name             "package_installer"
 maintainer       "Chris Roberts"
 maintainer_email "chrisroberts.code@gmail.com"
 license          "Apache 2.0"
 description      "Installs/Updates system packages"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.0.1"
-


### PR DESCRIPTION
We use spiceweasel to batch upload our chef repo.
It now validates the name attribute in the metadata.
  ERROR: Cookbook 'package_installer' does not match
  the name 'package_intaller' in package_installer/metadata.rb.
